### PR TITLE
Graceful quit

### DIFF
--- a/flightpath/game_loop.py
+++ b/flightpath/game_loop.py
@@ -55,6 +55,7 @@ class States(Enum):
   WAIT_FOR_START = 1
   IN_GAME = 2
   WAIT_FOR_RESET = 3
+  QUIT = 4
 
 # State of game
 cur_state = States.RESET_GAME.value
@@ -70,6 +71,7 @@ class PebbleKeys(Enum):
   GAME_LOSS = 5
   RESET_PRESS = 6
   START_PRESS = 7
+  QUIT_PRESS = 8
 
 # Pebble app properties
 pebble_app_uuid = uuid.UUID("7f1e9122-6a6b-4b58-8e1a-484d5c51e861")
@@ -109,6 +111,12 @@ def handler(self, uuid, data):
     print PebbleKeys.START_PRESS.name
     global cur_state
     cur_state = States.IN_GAME.value
+    print 'state', cur_state
+
+  if data[PebbleKeys.BUTTON_PRESS_KEY.value] == PebbleKeys.QUIT_PRESS.value:
+    print PebbleKeys.QUIT_PRESS.name
+    global cur_state
+    cur_state = States.QUIT.value
     print 'state', cur_state
 
 messenger = AppMessageService(pebble)
@@ -156,7 +164,7 @@ def reset_pos():
 
 reset_pos()
 
-while(True):
+while(cur_state != States.QUIT.value):
   print 'in while'
   global cur_state
   if cur_state == States.IN_GAME.value:

--- a/flightpath/game_objects.py
+++ b/flightpath/game_objects.py
@@ -34,7 +34,7 @@ class Ship:
 		self.position = position
 
 	def set_direction(self, direction):
-		self.position = position
+		self.direction = direction
 		self.d_vector = x_unit(self.direction)
 
 # Map contains the allowable locations for the ship, it will report

--- a/flightpath/game_objects.py
+++ b/flightpath/game_objects.py
@@ -34,7 +34,7 @@ class Ship:
 		self.position = position
 
 	def set_direction(self, direction):
-		self.direction = direction
+		self.position = position
 		self.d_vector = x_unit(self.direction)
 
 # Map contains the allowable locations for the ship, it will report

--- a/pebble/src/pebble.c
+++ b/pebble/src/pebble.c
@@ -14,7 +14,8 @@ enum {
   GAME_WIN = (uint8_t) 4,
   GAME_LOSS = (uint8_t) 5,
   RESET_PRESS = (uint8_t) 6,
-  START_PRESS = (uint8_t) 7
+  START_PRESS = (uint8_t) 7,
+  QUIT_PRESS = (uint8_t) 8
 };
 
 static void send_simple_dict(uint32_t key, uint8_t val) {
@@ -48,6 +49,12 @@ static void game_over_window_click_handler(ClickRecognizerRef recognizer, void *
   send_simple_dict(BUTTON_PRESS_KEY, RESET_PRESS);
 }
 
+static void quit_window_click_handler(ClickRecognizerRef recognizer, void *context) {
+  vibes_cancel();
+  send_simple_dict(BUTTON_PRESS_KEY, QUIT_PRESS);
+  window_stack_pop_all(true);
+}
+
 static void outbox_fail_callback(DictionaryIterator *iterator, AppMessageResult reason, void *context) {
   switch (reason) {
     case APP_MSG_SEND_TIMEOUT:
@@ -67,7 +74,7 @@ static void main_click_config_provider(void *context) {
 static void game_over_click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_UP, game_over_window_click_handler);
   window_single_click_subscribe(BUTTON_ID_DOWN, game_over_window_click_handler);
-  window_single_click_subscribe(BUTTON_ID_SELECT, game_over_window_click_handler);
+  window_single_click_subscribe(BUTTON_ID_SELECT, quit_window_click_handler);
   window_single_click_subscribe(BUTTON_ID_BACK, game_over_window_click_handler);
 }
 

--- a/pebble/src/pebble.c
+++ b/pebble/src/pebble.c
@@ -49,7 +49,7 @@ static void game_over_window_click_handler(ClickRecognizerRef recognizer, void *
   send_simple_dict(BUTTON_PRESS_KEY, RESET_PRESS);
 }
 
-static void quit_window_click_handler(ClickRecognizerRef recognizer, void *context) {
+static void quit_click_handler(ClickRecognizerRef recognizer, void *context) {
   vibes_cancel();
   send_simple_dict(BUTTON_PRESS_KEY, QUIT_PRESS);
   window_stack_pop_all(true);
@@ -74,7 +74,7 @@ static void main_click_config_provider(void *context) {
 static void game_over_click_config_provider(void *context) {
   window_single_click_subscribe(BUTTON_ID_UP, game_over_window_click_handler);
   window_single_click_subscribe(BUTTON_ID_DOWN, game_over_window_click_handler);
-  window_single_click_subscribe(BUTTON_ID_SELECT, quit_window_click_handler);
+  window_single_click_subscribe(BUTTON_ID_SELECT, quit_click_handler);
   window_single_click_subscribe(BUTTON_ID_BACK, game_over_window_click_handler);
 }
 


### PR DESCRIPTION
This pull request would allow the user to gracefully quit both the Pebble app and Python companion app by pressing the "Back" button on their watch after reaching a game over screen. Currently, the only way to quit the companion app is to Ctrl+Z the process, which may leave an open connection to the watch. Such unattended connection may cause problems when later attempting to pair with it.

Note: If such problems arise, they can be fixed by unpairing the watch from your computer's Bluetooth panel and cycling Bluetooth off and back on from your Pebble Time, then following the steps to pair the devices again as described in the Pebble README file.
